### PR TITLE
style: added generate panel button to title tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "commands": [
       {
         "command": "vscode-japanese-tei.openPreview",
-        "title": "generate panel"
+        "title": "generate panel",
+        "icon":"$(go-to-file)"
       },
       {
         "command": "vscode-japanese-tei.insertApp",
@@ -62,6 +63,13 @@
       }
     ],
     "menus": {
+      "editor/title": [
+        {
+          "when": "resourceLangId == xml",
+          "command": "vscode-japanese-tei.openPreview",
+          "group": "navigation"
+        }
+      ],
       "editor/context": [
         {
           "command": "vscode-japanese-tei.openPreview",


### PR DESCRIPTION
XMLファイルに限定しておりますが、プレビューパネルを開くボタンをタブの右上に追加いたしました。
![image](https://user-images.githubusercontent.com/2211964/165069288-f2933c2b-3aba-4163-8dfd-ac7f6fbff47a.png)

アイコンは適当に選んだので、[公式のiconサイト](https://code.visualstudio.com/api/references/icons-in-labels)ではいろいろあります！